### PR TITLE
Fix texture load error for octsetter.

### DIFF
--- a/map/def1a.cfg
+++ b/map/def1a.cfg
@@ -22,7 +22,7 @@ loop+ i 1 4 [
 
 texturereset            // Start world texture list
    texsky               // Dummy "sky" texture
-   texload "team/base1" // Default geometry texture
+   texload "base/base1" // Default geometry texture
    texload "team/teamblue" // blue team engineer block
    texload "team/teamred"  // red team engineer block
    texload "base/base4"


### PR DESCRIPTION
Cubes placed with the octsetter do not have a texture. The texture in the location `media/texture/team/base1` does not exist, but the texture in `media/texture/base/base1` does. The texture error can be seen in https://github.com/project-imprimis/imprimis/pull/66.

![image](https://user-images.githubusercontent.com/48164786/184445525-2e7559f0-4df1-4e8e-a44c-b3979e5b15d9.png)
